### PR TITLE
Handle VTODO occurrences when only DUE is set

### DIFF
--- a/lib/src/semantic/extensions/components.dart
+++ b/lib/src/semantic/extensions/components.dart
@@ -164,12 +164,13 @@ extension TodoComponentExtensions on TodoComponent {
   ///
   /// [start] and [end] can be provided to limit the occurrences.
   ///
-  /// Returns an empty iterable if the todo has no start date.
+  /// Returns an empty iterable if the todo has neither start nor due date.
   Iterable<CalDateTime> occurrences({CalDateTime? start, CalDateTime? end}) {
-    if (dtstart == null) return const Iterable<CalDateTime>.empty();
+    final startDate = dtstart ?? due;
+    if (startDate == null) return const Iterable<CalDateTime>.empty();
 
     final iterator = RecurrenceIterator(
-      dtstart: dtstart!,
+      dtstart: startDate,
       rrule: rrule,
       exdates: exdates,
       rdates: rdates,

--- a/lib/src/semantic/extensions/queries.dart
+++ b/lib/src/semantic/extensions/queries.dart
@@ -99,7 +99,7 @@ extension TodoIterableQuery on Iterable<TodoComponent> {
   Iterable<TodoOccurrence> occurrences({CalDateTime? start, CalDateTime? end}) {
     return _OccurrenceIterator.occurrences<TodoComponent>(
       components: this,
-      ignore: (todo) => todo.dtstart == null,
+      ignore: (todo) => todo.dtstart == null && todo.due == null,
       occurrences: (todo) => todo.occurrences(start: start, end: end),
     ).map((e) => (occurrence: e.occurrence, todo: e.component));
   }

--- a/test/semantic/extensions/components_test.dart
+++ b/test/semantic/extensions/components_test.dart
@@ -491,12 +491,29 @@ void main() {
       expect(occurrences[1], CalDateTime.local(2025, 1, 2, 10, 0, 0));
     });
 
-    test('occurrences returns empty iterable when DTSTART is null', () {
-      // Create a todo without DTSTART property
-      final todo = TodoComponent(properties: {}, components: []);
+    test(
+      'occurrences returns empty iterable when DTSTART and DUE are null',
+      () {
+        final todo = TodoComponent(properties: {}, components: []);
+
+        final occurrences = todo.occurrences().toList();
+        expect(occurrences, isEmpty);
+      },
+    );
+
+    test('occurrences uses DUE when DTSTART is null', () {
+      final parser = CalendarParser();
+      final todo = parser.parseComponentFromString<TodoComponent>(
+        'BEGIN:VTODO\r\n'
+        'UID:test-todo-due-fallback\r\n'
+        'DTSTAMP:20250101T000000Z\r\n'
+        'DUE:20250115T140000\r\n'
+        'END:VTODO',
+      );
 
       final occurrences = todo.occurrences().toList();
-      expect(occurrences, isEmpty);
+      expect(occurrences.length, 1);
+      expect(occurrences[0], CalDateTime.local(2025, 1, 15, 14, 0, 0));
     });
 
     test('effectiveDuration returns duration when present', () {

--- a/test/semantic/extensions/queries_test.dart
+++ b/test/semantic/extensions/queries_test.dart
@@ -2673,7 +2673,7 @@ END:VTIMEZONE''');
       expect(timezones.length, 0);
     });
 
-    test('Components with null dtstart for todos are handled', () {
+    test('Todos without DTSTART use DUE for occurrences', () {
       final parser = CalendarParser();
 
       // Todo without DTSTART (use DUE instead)
@@ -2702,9 +2702,11 @@ END:VTODO''');
         validTodo,
       ].occurrences(start: start, end: end).toList();
 
-      // Only valid todo with dtstart should be included
-      expect(results.length, 1);
-      expect(results[0].todo.summary, 'Valid Todo');
+      expect(results.length, 2);
+      expect(results[0].todo.summary, 'No Start Time');
+      expect(results[0].occurrence, CalDateTime.local(2025, 1, 15, 10, 0, 0));
+      expect(results[1].todo.summary, 'Valid Todo');
+      expect(results[1].occurrence, CalDateTime.local(2025, 1, 15, 10, 0, 0));
     });
 
     test('Large number of components maintains order efficiently', () {


### PR DESCRIPTION
Some VTODO entries can be valid without DTSTART and only provide DUE. Those todos were being dropped from occurrence queries, which made due-only tasks invisible in results.

## What changed
- Updated `TodoComponent.occurrences()` to use `dtstart ?? due` as the recurrence anchor.
- Kept empty results only for todos that have neither `DTSTART` nor `DUE`.
- Updated `TodoIterableQuery.occurrences()` filtering so due-only todos are no longer ignored.
- Added and updated tests to cover both behaviors:
  - due-only todos now produce occurrences
  - todos with neither DTSTART nor DUE still produce no occurrences

## Notes
This keeps existing recurrence and ordering behavior intact while aligning todo occurrence generation with due-only VTODO inputs.

Closes #25