### PR TITLE
Bump package version to 1.0.9

### DIFF
--- a/lib/src/semantic/extensions/components.dart
+++ b/lib/src/semantic/extensions/components.dart
@@ -164,12 +164,13 @@ extension TodoComponentExtensions on TodoComponent {
   ///
   /// [start] and [end] can be provided to limit the occurrences.
   ///
-  /// Returns an empty iterable if the todo has no start date.
+  /// Returns an empty iterable if the todo has neither start nor due date.
   Iterable<CalDateTime> occurrences({CalDateTime? start, CalDateTime? end}) {
-    if (dtstart == null) return const Iterable<CalDateTime>.empty();
+    final startDate = dtstart ?? due;
+    if (startDate == null) return const Iterable<CalDateTime>.empty();
 
     final iterator = RecurrenceIterator(
-      dtstart: dtstart!,
+      dtstart: startDate,
       rrule: rrule,
       exdates: exdates,
       rdates: rdates,

--- a/lib/src/semantic/extensions/queries.dart
+++ b/lib/src/semantic/extensions/queries.dart
@@ -99,7 +99,7 @@ extension TodoIterableQuery on Iterable<TodoComponent> {
   Iterable<TodoOccurrence> occurrences({CalDateTime? start, CalDateTime? end}) {
     return _OccurrenceIterator.occurrences<TodoComponent>(
       components: this,
-      ignore: (todo) => todo.dtstart == null,
+      ignore: (todo) => todo.dtstart == null && todo.due == null,
       occurrences: (todo) => todo.occurrences(start: start, end: end),
     ).map((e) => (occurrence: e.occurrence, todo: e.component));
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firstfloor_calendar
 description: RFC 5545 compliant iCalendar (.ics) parser for Dart and Flutter.
-version: 1.0.8
+version: 1.0.9
 repository: https://github.com/firstfloorsoftware/firstfloor_calendar
 topics:
   - icalendar

--- a/test/semantic/extensions/components_test.dart
+++ b/test/semantic/extensions/components_test.dart
@@ -491,12 +491,29 @@ void main() {
       expect(occurrences[1], CalDateTime.local(2025, 1, 2, 10, 0, 0));
     });
 
-    test('occurrences returns empty iterable when DTSTART is null', () {
-      // Create a todo without DTSTART property
-      final todo = TodoComponent(properties: {}, components: []);
+    test(
+      'occurrences returns empty iterable when DTSTART and DUE are null',
+      () {
+        final todo = TodoComponent(properties: {}, components: []);
+
+        final occurrences = todo.occurrences().toList();
+        expect(occurrences, isEmpty);
+      },
+    );
+
+    test('occurrences uses DUE when DTSTART is null', () {
+      final parser = CalendarParser();
+      final todo = parser.parseComponentFromString<TodoComponent>(
+        'BEGIN:VTODO\r\n'
+        'UID:test-todo-due-fallback\r\n'
+        'DTSTAMP:20250101T000000Z\r\n'
+        'DUE:20250115T140000\r\n'
+        'END:VTODO',
+      );
 
       final occurrences = todo.occurrences().toList();
-      expect(occurrences, isEmpty);
+      expect(occurrences.length, 1);
+      expect(occurrences[0], CalDateTime.local(2025, 1, 15, 14, 0, 0));
     });
 
     test('effectiveDuration returns duration when present', () {

--- a/test/semantic/extensions/queries_test.dart
+++ b/test/semantic/extensions/queries_test.dart
@@ -2673,7 +2673,7 @@ END:VTIMEZONE''');
       expect(timezones.length, 0);
     });
 
-    test('Components with null dtstart for todos are handled', () {
+    test('Todos without DTSTART use DUE for occurrences', () {
       final parser = CalendarParser();
 
       // Todo without DTSTART (use DUE instead)
@@ -2702,9 +2702,11 @@ END:VTODO''');
         validTodo,
       ].occurrences(start: start, end: end).toList();
 
-      // Only valid todo with dtstart should be included
-      expect(results.length, 1);
-      expect(results[0].todo.summary, 'Valid Todo');
+      expect(results.length, 2);
+      expect(results[0].todo.summary, 'No Start Time');
+      expect(results[0].occurrence, CalDateTime.local(2025, 1, 15, 10, 0, 0));
+      expect(results[1].todo.summary, 'Valid Todo');
+      expect(results[1].occurrence, CalDateTime.local(2025, 1, 15, 10, 0, 0));
     });
 
     test('Large number of components maintains order efficiently', () {


### PR DESCRIPTION
This follows up #26 by merging the package version bump into main so the branch state and release metadata are aligned.

## What changed
- Updates `pubspec.yaml` version from 1.0.8 to 1.0.9.

## Why
The previous PR merge brought in the code fix, but main still showed 1.0.8. This PR makes main fully current with the intended 1.0.9 release state.