### PR TITLE
Prepare 1.0.10 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.10] - 2026-07-03
+
+### Fixed
+- Added support for `RDATE;VALUE=PERIOD` in recurrence iteration.
+- Expanded `BYDAY` correctly when `BYWEEKNO` is present in yearly recurrence rules.
+
 ## [1.0.9] - 2026-07-03
 
 ### Fixed
@@ -95,6 +101,9 @@ All notable changes to this project will be documented in this file.
 - Timezone-aware date/time handling
 - Two-layer architecture (document + semantic)
 
+[1.0.10]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.10
+[1.0.9]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.9
+[1.0.8]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.8
 [1.0.7]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.7
 [1.0.6]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.6
 [1.0.5]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firstfloor_calendar
 description: RFC 5545 compliant iCalendar (.ics) parser for Dart and Flutter.
-version: 1.0.9
+version: 1.0.10
 repository: https://github.com/firstfloorsoftware/firstfloor_calendar
 topics:
   - icalendar


### PR DESCRIPTION
This PR stages the 1.0.10 release metadata so the next publish tag can be cut cleanly.

## What changed
- Bumped `pubspec.yaml` version from `1.0.9` to `1.0.10`.
- Added a new `1.0.10` changelog section summarizing the recent recurrence fixes:
  - `RDATE;VALUE=PERIOD` support in recurrence iteration
  - `BYDAY` expansion when `BYWEEKNO` is present
- Added missing changelog release links for `1.0.8` and `1.0.9` at the bottom of `CHANGELOG.md`.

## Notes
This is release-prep only (metadata/docs), with no runtime code changes.