### PR TITLE
Add iCalendar serialization support for document and semantic components

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A Dart library for parsing and working with iCalendar (.ics) files. Built with R
 - [Installation](#installation)
 - [Usage](#usage)
   - [Basic Parsing](#basic-parsing)
+  - [Serializing Back to iCalendar](#serializing-back-to-icalendar)
   - [Working with Events](#working-with-events)
   - [Working with Timezones](#working-with-timezones)
   - [Recurring Events](#recurring-events)
@@ -70,6 +71,26 @@ final calendar = parser.parseFromString(ics);
 for (final event in calendar.events) {
   print('${event.summary}: ${event.dtstart}');
 }
+```
+
+### Serializing Back to iCalendar
+
+You can serialize both document-layer and semantic components back to iCalendar
+text using `toICalendarString()`. The serializer emits CRLF line endings and
+applies RFC 5545 line folding by default.
+
+```dart
+final event = CalendarParser().parseComponentFromString<EventComponent>(
+  'BEGIN:VEVENT\r\n'
+  'UID:evt-1\r\n'
+  'DTSTAMP:20250703T120000Z\r\n'
+  'DTSTART:20250703T130000Z\r\n'
+  'SUMMARY:Serialized event\r\n'
+  'END:VEVENT',
+);
+
+final ics = event.toICalendarString();
+print(ics);
 ```
 
 ### Working with Events

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ for (final event in calendar.events) {
 ### Serializing Back to iCalendar
 
 You can serialize both document-layer and semantic components back to iCalendar
-text using `toICalendarString()`. The serializer emits CRLF line endings and
+text using `toIcsString()`. The serializer emits CRLF line endings and
 applies RFC 5545 line folding by default.
 
 ```dart
@@ -90,7 +90,7 @@ SUMMARY:Serialized event
 END:VEVENT''',
 );
 
-final ics = event.toICalendarString();
+final ics = event.toIcsString();
 print(ics);
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,12 +81,13 @@ applies RFC 5545 line folding by default.
 
 ```dart
 final event = CalendarParser().parseComponentFromString<EventComponent>(
-  'BEGIN:VEVENT\r\n'
-  'UID:evt-1\r\n'
-  'DTSTAMP:20250703T120000Z\r\n'
-  'DTSTART:20250703T130000Z\r\n'
-  'SUMMARY:Serialized event\r\n'
-  'END:VEVENT',
+  '''
+BEGIN:VEVENT
+UID:evt-1
+DTSTAMP:20250703T120000Z
+DTSTART:20250703T130000Z
+SUMMARY:Serialized event
+END:VEVENT''',
 );
 
 final ics = event.toICalendarString();

--- a/lib/src/document/document.dart
+++ b/lib/src/document/document.dart
@@ -1,3 +1,4 @@
 export 'calendar_document.dart';
+export 'document_serializer.dart';
 export 'document_parser.dart';
 export 'parser.dart' show ParseException;

--- a/lib/src/document/document_serializer.dart
+++ b/lib/src/document/document_serializer.dart
@@ -31,14 +31,14 @@ extension CalendarDocumentSerialization on CalendarDocumentComponent {
   ///
   /// Output includes `BEGIN:<NAME>` and `END:<NAME>` wrapper lines, nested
   /// components, CRLF line endings, and optional RFC 5545 line folding.
-  String toICalendarString({bool foldLines = true}) {
+  String toIcsString({bool foldLines = true}) {
     return serializeCalendarDocumentComponent(this, foldLines: foldLines);
   }
 }
 
 extension CalendarPropertySerialization on CalendarProperty {
   /// Serializes this property into an iCalendar content line.
-  String toICalendarString({bool foldLine = true}) {
+  String toIcsString({bool foldLine = true}) {
     return serializeCalendarProperty(this, foldLine: foldLine);
   }
 }

--- a/lib/src/document/document_serializer.dart
+++ b/lib/src/document/document_serializer.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+
+import 'calendar_document.dart';
+
+/// Serializes a raw [CalendarDocumentComponent] (or [CalendarDocument]) to iCalendar text.
+///
+/// Output always uses CRLF (`\r\n`) line endings. When [foldLines] is true,
+/// content lines are folded to RFC 5545's 75-octet limit.
+String serializeCalendarDocumentComponent(
+  CalendarDocumentComponent component, {
+  bool foldLines = true,
+}) {
+  final buffer = StringBuffer();
+  _writeComponent(buffer, component, foldLines: foldLines);
+  return buffer.toString();
+}
+
+/// Serializes a [CalendarProperty] into a single iCalendar content line.
+String serializeCalendarProperty(
+  CalendarProperty property, {
+  bool foldLine = true,
+}) {
+  final line = property.toString();
+  if (!foldLine) return line;
+  return _foldContentLine(line);
+}
+
+/// Serialization extensions for document-layer components and properties.
+extension CalendarDocumentSerialization on CalendarDocumentComponent {
+  /// Serializes this component into iCalendar text.
+  ///
+  /// Output includes `BEGIN:<NAME>` and `END:<NAME>` wrapper lines, nested
+  /// components, CRLF line endings, and optional RFC 5545 line folding.
+  String toICalendarString({bool foldLines = true}) {
+    return serializeCalendarDocumentComponent(this, foldLines: foldLines);
+  }
+}
+
+extension CalendarPropertySerialization on CalendarProperty {
+  /// Serializes this property into an iCalendar content line.
+  String toICalendarString({bool foldLine = true}) {
+    return serializeCalendarProperty(this, foldLine: foldLine);
+  }
+}
+
+void _writeComponent(
+  StringBuffer buffer,
+  CalendarDocumentComponent component, {
+  required bool foldLines,
+}) {
+  _writeLine(buffer, 'BEGIN:${component.name}');
+
+  for (final property in component.properties) {
+    _writeLine(
+      buffer,
+      serializeCalendarProperty(property, foldLine: foldLines),
+      alreadyFolded: foldLines,
+    );
+  }
+
+  for (final child in component.components) {
+    _writeComponent(buffer, child, foldLines: foldLines);
+  }
+
+  _writeLine(buffer, 'END:${component.name}');
+}
+
+void _writeLine(
+  StringBuffer buffer,
+  String line, {
+  bool alreadyFolded = false,
+}) {
+  if (alreadyFolded) {
+    buffer.write(line);
+    buffer.write('\r\n');
+    return;
+  }
+
+  buffer.write(line);
+  buffer.write('\r\n');
+}
+
+String _foldContentLine(String line) {
+  if (utf8.encode(line).length <= 75) return line;
+
+  final out = StringBuffer();
+  var currentLineOctets = 0;
+
+  for (final rune in line.runes) {
+    final char = String.fromCharCode(rune);
+    final charOctets = utf8.encode(char).length;
+
+    if (currentLineOctets + charOctets > 75) {
+      out.write('\r\n ');
+      currentLineOctets = 1; // continuation whitespace
+    }
+
+    out.write(char);
+    currentLineOctets += charOctets;
+  }
+
+  return out.toString();
+}

--- a/lib/src/document/document_serializer.dart
+++ b/lib/src/document/document_serializer.dart
@@ -15,7 +15,11 @@ String serializeCalendarDocumentComponent(
   return buffer.toString();
 }
 
-/// Serializes a [CalendarProperty] into a single iCalendar content line.
+/// Serializes a [CalendarProperty] into a single iCalendar content line body.
+///
+/// The returned string does not include a trailing CRLF line terminator.
+/// When [foldLine] is true, the content is folded to RFC 5545's 75-octet
+/// limit using CRLF + whitespace continuations.
 String serializeCalendarProperty(
   CalendarProperty property, {
   bool foldLine = true,
@@ -54,7 +58,6 @@ void _writeComponent(
     _writeLine(
       buffer,
       serializeCalendarProperty(property, foldLine: foldLines),
-      alreadyFolded: foldLines,
     );
   }
 
@@ -65,17 +68,7 @@ void _writeComponent(
   _writeLine(buffer, 'END:${component.name}');
 }
 
-void _writeLine(
-  StringBuffer buffer,
-  String line, {
-  bool alreadyFolded = false,
-}) {
-  if (alreadyFolded) {
-    buffer.write(line);
-    buffer.write('\r\n');
-    return;
-  }
-
+void _writeLine(StringBuffer buffer, String line) {
   buffer.write(line);
   buffer.write('\r\n');
 }

--- a/lib/src/document/document_serializer.dart
+++ b/lib/src/document/document_serializer.dart
@@ -41,7 +41,11 @@ extension CalendarDocumentSerialization on CalendarDocumentComponent {
 }
 
 extension CalendarPropertySerialization on CalendarProperty {
-  /// Serializes this property into an iCalendar content line.
+  /// Serializes this property into an iCalendar content line body.
+  ///
+  /// The returned string does not include a trailing CRLF line terminator.
+  /// When [foldLine] is true, the content is folded to RFC 5545's 75-octet
+  /// limit using CRLF + whitespace continuations.
   String toIcsString({bool foldLine = true}) {
     return serializeCalendarProperty(this, foldLine: foldLine);
   }

--- a/lib/src/semantic/extensions/extensions.dart
+++ b/lib/src/semantic/extensions/extensions.dart
@@ -1,3 +1,4 @@
 export 'calendar_types.dart';
 export 'components.dart';
 export 'queries.dart';
+export 'serialization.dart';

--- a/lib/src/semantic/extensions/serialization.dart
+++ b/lib/src/semantic/extensions/serialization.dart
@@ -11,7 +11,7 @@ extension CalendarComponentSerialization on CalendarComponent {
   ///
   /// Output includes `BEGIN:<NAME>` and `END:<NAME>` wrapper lines, nested
   /// components, CRLF line endings, and optional RFC 5545 line folding.
-  String toICalendarString({bool foldLines = true}) {
+  String toIcsString({bool foldLines = true}) {
     final documentComponent = _toDocumentComponent(this);
     return serializeCalendarDocumentComponent(
       documentComponent,

--- a/lib/src/semantic/extensions/serialization.dart
+++ b/lib/src/semantic/extensions/serialization.dart
@@ -1,5 +1,5 @@
 import '../../document/document.dart';
-import '../calendar.dart';
+import '../semantic.dart';
 
 /// Serialization helpers for semantic components.
 extension CalendarComponentSerialization on CalendarComponent {

--- a/lib/src/semantic/extensions/serialization.dart
+++ b/lib/src/semantic/extensions/serialization.dart
@@ -1,0 +1,61 @@
+import '../../document/document.dart';
+import '../calendar.dart';
+
+/// Serialization helpers for semantic components.
+extension CalendarComponentSerialization on CalendarComponent {
+  /// Serializes this semantic component into iCalendar text.
+  ///
+  /// For components parsed from source, this uses the original raw property
+  /// strings retained by the parser. For programmatically created components,
+  /// the output reflects the provided [PropertyValue.property] metadata.
+  ///
+  /// Output includes `BEGIN:<NAME>` and `END:<NAME>` wrapper lines, nested
+  /// components, CRLF line endings, and optional RFC 5545 line folding.
+  String toICalendarString({bool foldLines = true}) {
+    final documentComponent = _toDocumentComponent(this);
+    return serializeCalendarDocumentComponent(
+      documentComponent,
+      foldLines: foldLines,
+    );
+  }
+}
+
+CalendarDocumentComponent _toDocumentComponent(CalendarComponent component) {
+  return CalendarDocumentComponent(
+    name: component.name,
+    properties: _orderedProperties(component.properties),
+    components: component.components
+        .map(_toDocumentComponent)
+        .toList(growable: false),
+  );
+}
+
+List<CalendarProperty> _orderedProperties(
+  Map<String, List<PropertyValue>> properties,
+) {
+  final indexed = <({int index, CalendarProperty property})>[];
+  var index = 0;
+  for (final entry in properties.entries) {
+    for (final value in entry.value) {
+      indexed.add((index: index++, property: value.property));
+    }
+  }
+
+  indexed.sort((a, b) {
+    final aHasLine = a.property.lineNumber > 0;
+    final bHasLine = b.property.lineNumber > 0;
+
+    if (aHasLine && bHasLine) {
+      final lineCompare = a.property.lineNumber.compareTo(
+        b.property.lineNumber,
+      );
+      if (lineCompare != 0) return lineCompare;
+    } else if (aHasLine != bHasLine) {
+      return aHasLine ? -1 : 1;
+    }
+
+    return a.index.compareTo(b.index);
+  });
+
+  return indexed.map((e) => e.property).toList(growable: false);
+}

--- a/test/document/document_serializer_test.dart
+++ b/test/document/document_serializer_test.dart
@@ -1,0 +1,51 @@
+import 'package:firstfloor_calendar/firstfloor_calendar.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Document serialization', () {
+    test('serializes a simple component with CRLF line endings', () {
+      final component = DocumentParser().parseComponent(
+        'BEGIN:VEVENT\r\n'
+        'UID:test-event\r\n'
+        'SUMMARY:Test Event\r\n'
+        'END:VEVENT',
+      );
+
+      final serialized = component.toICalendarString();
+
+      expect(
+        serialized,
+        'BEGIN:VEVENT\r\n'
+        'UID:test-event\r\n'
+        'SUMMARY:Test Event\r\n'
+        'END:VEVENT\r\n',
+      );
+    });
+
+    test('folds long content lines and remains parseable', () {
+      const description =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      final component = CalendarDocumentComponent(
+        name: 'VEVENT',
+        properties: const [
+          CalendarProperty(name: 'UID', value: 'event-1'),
+          CalendarProperty(name: 'DESCRIPTION', value: description),
+        ],
+      );
+
+      final serialized = component.toICalendarString();
+      final reparsed = DocumentParser().parseComponent(serialized);
+
+      expect(serialized, contains('\r\n '));
+      expect(reparsed.value('DESCRIPTION'), description);
+    });
+
+    test('can disable line folding for a single property', () {
+      final property = CalendarProperty(name: 'DESCRIPTION', value: 'a' * 120);
+
+      final serialized = property.toICalendarString(foldLine: false);
+      expect(serialized, isNot(contains('\r\n ')));
+    });
+  });
+}

--- a/test/document/document_serializer_test.dart
+++ b/test/document/document_serializer_test.dart
@@ -47,7 +47,10 @@ END:VEVENT
     });
 
     test('can disable line folding for a single property', () {
-      final property = CalendarProperty(name: 'DESCRIPTION', value: 'a' * 120);
+      final property = CalendarProperty(
+        name: 'DESCRIPTION',
+        value: List.filled(120, 'a').join(),
+      );
 
       final serialized = property.toIcsString(foldLine: false);
       expect(serialized, isNot(contains('\r\n ')));

--- a/test/document/document_serializer_test.dart
+++ b/test/document/document_serializer_test.dart
@@ -2,23 +2,28 @@ import 'package:firstfloor_calendar/firstfloor_calendar.dart';
 import 'package:test/test.dart';
 
 void main() {
+  String crlf(String value) => value.replaceAll('\n', '\r\n');
+
   group('Document serialization', () {
     test('serializes a simple component with CRLF line endings', () {
       final component = DocumentParser().parseComponent(
-        'BEGIN:VEVENT\r\n'
-        'UID:test-event\r\n'
-        'SUMMARY:Test Event\r\n'
-        'END:VEVENT',
+        crlf('''
+BEGIN:VEVENT
+UID:test-event
+SUMMARY:Test Event
+END:VEVENT'''),
       );
 
       final serialized = component.toICalendarString();
 
       expect(
         serialized,
-        'BEGIN:VEVENT\r\n'
-        'UID:test-event\r\n'
-        'SUMMARY:Test Event\r\n'
-        'END:VEVENT\r\n',
+        crlf('''
+BEGIN:VEVENT
+UID:test-event
+SUMMARY:Test Event
+END:VEVENT
+'''),
       );
     });
 

--- a/test/document/document_serializer_test.dart
+++ b/test/document/document_serializer_test.dart
@@ -14,7 +14,7 @@ SUMMARY:Test Event
 END:VEVENT'''),
       );
 
-      final serialized = component.toICalendarString();
+      final serialized = component.toIcsString();
 
       expect(
         serialized,
@@ -39,7 +39,7 @@ END:VEVENT
         ],
       );
 
-      final serialized = component.toICalendarString();
+      final serialized = component.toIcsString();
       final reparsed = DocumentParser().parseComponent(serialized);
 
       expect(serialized, contains('\r\n '));
@@ -49,7 +49,7 @@ END:VEVENT
     test('can disable line folding for a single property', () {
       final property = CalendarProperty(name: 'DESCRIPTION', value: 'a' * 120);
 
-      final serialized = property.toICalendarString(foldLine: false);
+      final serialized = property.toIcsString(foldLine: false);
       expect(serialized, isNot(contains('\r\n ')));
     });
   });

--- a/test/semantic/serialization_test.dart
+++ b/test/semantic/serialization_test.dart
@@ -18,7 +18,7 @@ DTSTART;TZID=America/New_York:20250703T090000
 SUMMARY:Serialization test
 END:VEVENT''');
 
-      final serialized = component.toICalendarString();
+      final serialized = component.toIcsString();
       final reparsed = DocumentParser().parseComponent(serialized);
 
       expect(serialized, contains('BEGIN:VEVENT\r\n'));
@@ -43,7 +43,7 @@ SUMMARY:Calendar serialization
 END:VEVENT
 END:VCALENDAR''');
 
-      final serialized = calendar.toICalendarString();
+      final serialized = calendar.toIcsString();
       final reparsed = DocumentParser().parse(serialized);
 
       expect(reparsed.value('VERSION'), '2.0');

--- a/test/semantic/serialization_test.dart
+++ b/test/semantic/serialization_test.dart
@@ -1,0 +1,56 @@
+import 'package:firstfloor_calendar/firstfloor_calendar.dart';
+import 'package:test/test.dart';
+import 'package:timezone/data/latest.dart' as tz;
+
+void main() {
+  setUpAll(() {
+    tz.initializeTimeZones();
+  });
+
+  group('Semantic serialization', () {
+    test('serializes a semantic component back to iCalendar text', () {
+      final component = CalendarParser()
+          .parseComponentFromString<EventComponent>(
+            'BEGIN:VEVENT\r\n'
+            'UID:evt-1\r\n'
+            'DTSTAMP:20250703T120000Z\r\n'
+            'DTSTART;TZID=America/New_York:20250703T090000\r\n'
+            'SUMMARY:Serialization test\r\n'
+            'END:VEVENT',
+          );
+
+      final serialized = component.toICalendarString();
+      final reparsed = DocumentParser().parseComponent(serialized);
+
+      expect(serialized, contains('BEGIN:VEVENT\r\n'));
+      expect(serialized, contains('END:VEVENT\r\n'));
+      expect(reparsed.value('DTSTART'), '20250703T090000');
+      expect(reparsed.propertiesNamed('DTSTART').first.parameters['TZID'], [
+        'America/New_York',
+      ]);
+      expect(reparsed.value('SUMMARY'), 'Serialization test');
+    });
+
+    test('serializes a semantic calendar with nested components', () {
+      final calendar = CalendarParser().parseFromString(
+        'BEGIN:VCALENDAR\r\n'
+        'VERSION:2.0\r\n'
+        'PRODID:-//firstfloor//serialization//EN\r\n'
+        'BEGIN:VEVENT\r\n'
+        'UID:evt-2\r\n'
+        'DTSTAMP:20250703T120000Z\r\n'
+        'DTSTART:20250710T100000Z\r\n'
+        'SUMMARY:Calendar serialization\r\n'
+        'END:VEVENT\r\n'
+        'END:VCALENDAR',
+      );
+
+      final serialized = calendar.toICalendarString();
+      final reparsed = DocumentParser().parse(serialized);
+
+      expect(reparsed.value('VERSION'), '2.0');
+      expect(reparsed.value('PRODID'), '-//firstfloor//serialization//EN');
+      expect(reparsed.componentsNamed('VEVENT').single.value('UID'), 'evt-2');
+    });
+  });
+}

--- a/test/semantic/serialization_test.dart
+++ b/test/semantic/serialization_test.dart
@@ -10,14 +10,13 @@ void main() {
   group('Semantic serialization', () {
     test('serializes a semantic component back to iCalendar text', () {
       final component = CalendarParser()
-          .parseComponentFromString<EventComponent>(
-            'BEGIN:VEVENT\r\n'
-            'UID:evt-1\r\n'
-            'DTSTAMP:20250703T120000Z\r\n'
-            'DTSTART;TZID=America/New_York:20250703T090000\r\n'
-            'SUMMARY:Serialization test\r\n'
-            'END:VEVENT',
-          );
+          .parseComponentFromString<EventComponent>('''
+BEGIN:VEVENT
+UID:evt-1
+DTSTAMP:20250703T120000Z
+DTSTART;TZID=America/New_York:20250703T090000
+SUMMARY:Serialization test
+END:VEVENT''');
 
       final serialized = component.toICalendarString();
       final reparsed = DocumentParser().parseComponent(serialized);
@@ -32,18 +31,17 @@ void main() {
     });
 
     test('serializes a semantic calendar with nested components', () {
-      final calendar = CalendarParser().parseFromString(
-        'BEGIN:VCALENDAR\r\n'
-        'VERSION:2.0\r\n'
-        'PRODID:-//firstfloor//serialization//EN\r\n'
-        'BEGIN:VEVENT\r\n'
-        'UID:evt-2\r\n'
-        'DTSTAMP:20250703T120000Z\r\n'
-        'DTSTART:20250710T100000Z\r\n'
-        'SUMMARY:Calendar serialization\r\n'
-        'END:VEVENT\r\n'
-        'END:VCALENDAR',
-      );
+      final calendar = CalendarParser().parseFromString('''
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//firstfloor//serialization//EN
+BEGIN:VEVENT
+UID:evt-2
+DTSTAMP:20250703T120000Z
+DTSTART:20250710T100000Z
+SUMMARY:Calendar serialization
+END:VEVENT
+END:VCALENDAR''');
 
       final serialized = calendar.toICalendarString();
       final reparsed = DocumentParser().parse(serialized);

--- a/test/semantic/serialization_test.dart
+++ b/test/semantic/serialization_test.dart
@@ -50,5 +50,93 @@ END:VCALENDAR''');
       expect(reparsed.value('PRODID'), '-//firstfloor//serialization//EN');
       expect(reparsed.componentsNamed('VEVENT').single.value('UID'), 'evt-2');
     });
+
+    test('preserves UTC date-time values with Z suffix', () {
+      final component = CalendarParser()
+          .parseComponentFromString<EventComponent>('''
+BEGIN:VEVENT
+UID:evt-utc
+DTSTAMP:20250703T120000Z
+DTSTART:20250703T130000Z
+DTEND:20250703T140000Z
+SUMMARY:UTC serialization
+END:VEVENT''');
+
+      final serialized = component.toIcsString();
+      final reparsed = DocumentParser().parseComponent(serialized);
+
+      expect(reparsed.value('DTSTART'), '20250703T130000Z');
+      expect(reparsed.value('DTEND'), '20250703T140000Z');
+      expect(
+        reparsed.propertiesNamed('DTSTART').first.parameters['TZID'],
+        isNull,
+      );
+    });
+
+    test('preserves floating local date-time values (without TZID)', () {
+      final component = CalendarParser()
+          .parseComponentFromString<EventComponent>('''
+BEGIN:VEVENT
+UID:evt-floating
+DTSTAMP:20250703T120000Z
+DTSTART:20250703T090000
+DTEND:20250703T100000
+SUMMARY:Floating serialization
+END:VEVENT''');
+
+      final serialized = component.toIcsString();
+      final reparsed = DocumentParser().parseComponent(serialized);
+
+      expect(reparsed.value('DTSTART'), '20250703T090000');
+      expect(reparsed.value('DTEND'), '20250703T100000');
+      expect(
+        reparsed.propertiesNamed('DTSTART').first.parameters['TZID'],
+        isNull,
+      );
+    });
+
+    test('preserves TZID parameters on date-time properties', () {
+      final component = CalendarParser()
+          .parseComponentFromString<EventComponent>('''
+BEGIN:VEVENT
+UID:evt-tzid
+DTSTAMP:20250703T120000Z
+DTSTART;TZID=Europe/Amsterdam:20250703T090000
+EXDATE;TZID=Europe/Amsterdam:20250710T090000
+SUMMARY:TZID serialization
+END:VEVENT''');
+
+      final serialized = component.toIcsString();
+      final reparsed = DocumentParser().parseComponent(serialized);
+
+      final dtstart = reparsed.propertiesNamed('DTSTART').single;
+      final exdate = reparsed.propertiesNamed('EXDATE').single;
+      expect(dtstart.parameters['TZID'], ['Europe/Amsterdam']);
+      expect(exdate.parameters['TZID'], ['Europe/Amsterdam']);
+      expect(dtstart.value, '20250703T090000');
+      expect(exdate.value, '20250710T090000');
+    });
+
+    test('preserves VALUE=DATE for all-day date values', () {
+      final component = CalendarParser()
+          .parseComponentFromString<EventComponent>('''
+BEGIN:VEVENT
+UID:evt-date
+DTSTAMP:20250703T120000Z
+DTSTART;VALUE=DATE:20250703
+DTEND;VALUE=DATE:20250704
+SUMMARY:Date-only serialization
+END:VEVENT''');
+
+      final serialized = component.toIcsString();
+      final reparsed = DocumentParser().parseComponent(serialized);
+
+      final dtstart = reparsed.propertiesNamed('DTSTART').single;
+      final dtend = reparsed.propertiesNamed('DTEND').single;
+      expect(dtstart.parameters['VALUE'], ['DATE']);
+      expect(dtend.parameters['VALUE'], ['DATE']);
+      expect(dtstart.value, '20250703');
+      expect(dtend.value, '20250704');
+    });
   });
 }


### PR DESCRIPTION
Issue #32 asks for an easy way to generate iCalendar text from parsed components. This PR adds a dedicated serialization API in both layers so callers can round-trip parsed data back into RFC 5545-style `.ics` text without hand-building lines.

## Why
Today the library parses iCalendar well, but there is no first-class way to serialize components back to text. That creates friction for workflows like read-modify-write, export, and debugging reconstructed components.

## What this adds
1. **Document-layer serializer**
- New `lib/src/document/document_serializer.dart`
- Public APIs:
  - `serializeCalendarDocumentComponent(...)`
  - `serializeCalendarProperty(...)`
  - `toICalendarString()` extension on `CalendarDocumentComponent`
  - `toICalendarString()` extension on `CalendarProperty`
- Behavior:
  - emits `BEGIN:/END:` wrappers recursively
  - uses CRLF line endings
  - applies RFC 5545 line folding (75 octets) by default

2. **Semantic-layer serializer**
- New `lib/src/semantic/extensions/serialization.dart`
- Public API:
  - `toICalendarString()` extension on `CalendarComponent`
- Implementation detail:
  - builds a document-layer representation from semantic components
  - preserves original source property metadata (`PropertyValue.property`) so parsed components serialize using their raw property strings/parameters
  - orders properties by original line number when available, with stable fallback ordering

3. **Exports and docs**
- Exported serializer from `lib/src/document/document.dart`
- Exported semantic serialization extension via `lib/src/semantic/extensions/extensions.dart`
- README usage section added: **Serializing Back to iCalendar**

## Tests
Added focused coverage for both layers:
- `test/document/document_serializer_test.dart`
  - CRLF output and wrapper structure
  - long-line folding remains parseable
  - fold disable option on property serialization
- `test/semantic/serialization_test.dart`
  - semantic component serialization round-trip with parameters (e.g. `TZID`)
  - full calendar serialization round-trip with nested components

Closes #32