### PR TITLE
Prepare 1.0.11 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.11] - 2026-07-03
+
+### Added
+- Added first-class iCalendar serialization API for document and semantic components via `toIcsString()`.
+
+### Improved
+- Added broader date-time serialization test coverage (UTC, floating local, TZID, and VALUE=DATE).
+
 ## [1.0.10] - 2026-07-03
 
 ### Fixed
@@ -101,6 +109,7 @@ All notable changes to this project will be documented in this file.
 - Timezone-aware date/time handling
 - Two-layer architecture (document + semantic)
 
+[1.0.11]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.11
 [1.0.10]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.10
 [1.0.9]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.9
 [1.0.8]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firstfloor_calendar
 description: RFC 5545 compliant iCalendar (.ics) parser for Dart and Flutter.
-version: 1.0.10
+version: 1.0.11
 repository: https://github.com/firstfloorsoftware/firstfloor_calendar
 topics:
   - icalendar


### PR DESCRIPTION
This PR prepares the next release metadata for 1.0.11.

## What changed
- Bumped `pubspec.yaml` version from `1.0.10` to `1.0.11`.
- Added a new `1.0.11` changelog section covering:
  - the new `toIcsString()` serialization API
  - expanded date-time serialization test coverage
- Added the `[1.0.11]` release link at the bottom of `CHANGELOG.md`.

## Scope
Release metadata/docs only; no runtime behavior changes in this PR.