### PR TITLE
Update dependencies to satisfy latest-version pub.dev score

### DIFF
--- a/lib/src/semantic/calendar_types.dart
+++ b/lib/src/semantic/calendar_types.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 import 'package:collection/collection.dart';
-import 'package:timezone/standalone.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
 
 import 'semantic.dart';
 
@@ -133,17 +133,15 @@ class CalDateTime implements Comparable<CalDateTime> {
          month,
          day,
          CalTime.local(hour, minute, second, tzid: tzid),
-         tzid != null
-             ? tz.TZDateTime(
-                 tz.getLocation(tzid),
-                 year,
-                 month,
-                 day,
-                 hour,
-                 minute,
-                 second,
-               )
-             : DateTime(year, month, day, hour, minute, second),
+         _buildNativeLocalDateTime(
+           year,
+           month,
+           day,
+           hour,
+           minute,
+           second,
+           tzid: tzid,
+         ),
        );
 
   /// Creates a DATE-TIME value with UTC time ('Z').
@@ -226,24 +224,16 @@ class CalDateTime implements Comparable<CalDateTime> {
     final newTzid = tzid ?? time!.tzid;
 
     // preserve the timezone information
-    final result = (newTzid != null)
-        ? tz.TZDateTime(
-            tz.getLocation(newTzid),
-            newYear,
-            newMonth,
-            newDay,
-            newHour,
-            newMinute,
-            newSecond,
-          )
-        : native.copyWith(
-            year: newYear,
-            month: newMonth,
-            day: newDay,
-            hour: newHour,
-            minute: newMinute,
-            second: newSecond,
-          );
+    final result = _buildNativeLocalDateTime(
+      newYear,
+      newMonth,
+      newDay,
+      newHour,
+      newMinute,
+      newSecond,
+      tzid: newTzid,
+      fallback: native,
+    );
 
     return CalDateTime._(
       result.year,
@@ -291,6 +281,55 @@ class CalDateTime implements Comparable<CalDateTime> {
         '${day.toString().padLeft(2, '0')}';
 
     return time != null ? '${date}T${time.toString()}' : date;
+  }
+
+  static DateTime _buildNativeLocalDateTime(
+    int year,
+    int month,
+    int day,
+    int hour,
+    int minute,
+    int second, {
+    String? tzid,
+    DateTime? fallback,
+  }) {
+    if (tzid == null) {
+      if (fallback == null) {
+        return DateTime(year, month, day, hour, minute, second);
+      }
+      return fallback.copyWith(
+        year: year,
+        month: month,
+        day: day,
+        hour: hour,
+        minute: minute,
+        second: second,
+      );
+    }
+
+    try {
+      return tz.TZDateTime(
+        tz.getLocation(tzid),
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+      );
+    } on tz.LocationNotFoundException {
+      if (fallback == null) {
+        return DateTime(year, month, day, hour, minute, second);
+      }
+      return fallback.copyWith(
+        year: year,
+        month: month,
+        day: day,
+        hour: hour,
+        minute: minute,
+        second: second,
+      );
+    }
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
  collection: ^1.19.1
- timezone: ^0.10.1
+ timezone: ^0.11.1
 
 dev_dependencies:
   lints: ^6.0.0


### PR DESCRIPTION
## Summary
- update `timezone` dependency constraint from `^0.10.1` to `^0.11.1`
- keep timezone-aware parsing compatible with canonical-only timezone databases by falling back when a TZID alias is unavailable
- preserve original TZID metadata on parsed values so round-trip serialization remains intact

## Why
pub.dev was reporting that not all dependencies are supported in their latest version.

## Validation
- `dart pub outdated` now reports no outdated constrained dependencies
- `dart analyze --fatal-infos`
- `dart test`

Closes #35
