### PR TITLE
Prepare 1.0.12 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.12] - 2026-07-05
+
+### Improved
+- Updated dependency constraints to support the latest `timezone` package release.
+
+### Fixed
+- Kept timezone-aware date-time parsing resilient when TZID aliases are unavailable in canonical timezone datasets.
+
 ## [1.0.11] - 2026-07-03
 
 ### Added
@@ -109,6 +117,7 @@ All notable changes to this project will be documented in this file.
 - Timezone-aware date/time handling
 - Two-layer architecture (document + semantic)
 
+[1.0.12]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.12
 [1.0.11]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.11
 [1.0.10]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.10
 [1.0.9]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.9

--- a/lib/src/semantic/calendar_types.dart
+++ b/lib/src/semantic/calendar_types.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 import 'package:collection/collection.dart';
-import 'package:timezone/standalone.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
 
 import 'semantic.dart';
 
@@ -133,17 +133,15 @@ class CalDateTime implements Comparable<CalDateTime> {
          month,
          day,
          CalTime.local(hour, minute, second, tzid: tzid),
-         tzid != null
-             ? tz.TZDateTime(
-                 tz.getLocation(tzid),
-                 year,
-                 month,
-                 day,
-                 hour,
-                 minute,
-                 second,
-               )
-             : DateTime(year, month, day, hour, minute, second),
+         _buildNativeLocalDateTime(
+           year,
+           month,
+           day,
+           hour,
+           minute,
+           second,
+           tzid: tzid,
+         ),
        );
 
   /// Creates a DATE-TIME value with UTC time ('Z').
@@ -226,24 +224,16 @@ class CalDateTime implements Comparable<CalDateTime> {
     final newTzid = tzid ?? time!.tzid;
 
     // preserve the timezone information
-    final result = (newTzid != null)
-        ? tz.TZDateTime(
-            tz.getLocation(newTzid),
-            newYear,
-            newMonth,
-            newDay,
-            newHour,
-            newMinute,
-            newSecond,
-          )
-        : native.copyWith(
-            year: newYear,
-            month: newMonth,
-            day: newDay,
-            hour: newHour,
-            minute: newMinute,
-            second: newSecond,
-          );
+    final result = _buildNativeLocalDateTime(
+      newYear,
+      newMonth,
+      newDay,
+      newHour,
+      newMinute,
+      newSecond,
+      tzid: newTzid,
+      fallback: native,
+    );
 
     return CalDateTime._(
       result.year,
@@ -291,6 +281,55 @@ class CalDateTime implements Comparable<CalDateTime> {
         '${day.toString().padLeft(2, '0')}';
 
     return time != null ? '${date}T${time.toString()}' : date;
+  }
+
+  static DateTime _buildNativeLocalDateTime(
+    int year,
+    int month,
+    int day,
+    int hour,
+    int minute,
+    int second, {
+    String? tzid,
+    DateTime? fallback,
+  }) {
+    if (tzid == null) {
+      if (fallback == null) {
+        return DateTime(year, month, day, hour, minute, second);
+      }
+      return fallback.copyWith(
+        year: year,
+        month: month,
+        day: day,
+        hour: hour,
+        minute: minute,
+        second: second,
+      );
+    }
+
+    try {
+      return tz.TZDateTime(
+        tz.getLocation(tzid),
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+      );
+    } on tz.LocationNotFoundException {
+      if (fallback == null) {
+        return DateTime(year, month, day, hour, minute, second);
+      }
+      return fallback.copyWith(
+        year: year,
+        month: month,
+        day: day,
+        hour: hour,
+        minute: minute,
+        second: second,
+      );
+    }
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
  collection: ^1.19.1
- timezone: ^0.10.1
+ timezone: ^0.11.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firstfloor_calendar
 description: RFC 5545 compliant iCalendar (.ics) parser for Dart and Flutter.
-version: 1.0.11
+version: 1.0.12
 repository: https://github.com/firstfloorsoftware/firstfloor_calendar
 topics:
   - icalendar


### PR DESCRIPTION
## Summary
- bump package version to `1.0.12`
- add `1.0.12` changelog entry
- include release notes for latest dependency support and timezone alias resilience

## Includes
- dependency support update from #36 (`timezone` constraint to latest supported)
- resilient TZID handling when alias names are not present in canonical timezone datasets

## Validation
- `dart analyze --fatal-infos`
- `dart test`
- `dart pub outdated`
