### PR TITLE
Add release policy and release PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,17 @@
+## Release checklist
+
+- [ ] Branch created from `origin/main` (release prep branch)
+- [ ] `pubspec.yaml` version bumped
+- [ ] `CHANGELOG.md` contains release notes for this version
+- [ ] `CHANGELOG.md` version links updated
+- [ ] CI checks pass (format, analyze, test)
+- [ ] PR title follows `Prepare <version> release metadata`
+- [ ] Release steps follow [`RELEASE.md`](../../RELEASE.md)
+
+## Version
+
+<!-- Example: 1.0.12 -->
+
+## Notes
+
+<!-- Optional release notes context -->

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A Dart library for parsing and working with iCalendar (.ics) files. Built with R
   - [Document Layer](#document-layer)
   - [Semantic Layer](#semantic-layer)
   - [Layer Interaction](#layer-interaction)
+- [Release Policy](#release-policy)
 - [License](#license)
 
 ## Features
@@ -398,6 +399,11 @@ final calendar = CalendarParser().parseFromString(ics);
 ```
 
 You can also bridge from document to semantic selectively using extension methods like `toEvent()`, `toTodo()`, etc.
+
+## Release Policy
+
+For maintainers, the release checklist and policy are documented in
+[`RELEASE.md`](RELEASE.md).
 
 ## License
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,49 @@
+# Release Policy
+
+This document defines the release process for `firstfloor_calendar`.
+
+## Scope
+
+Use this process for every published version (for example, `1.0.12`).
+
+## Rules
+
+1. Never push directly to `main`; release changes must go through PRs.
+2. `pubspec.yaml` version and changelog entry must be updated together.
+3. Publish is triggered by a Git tag matching the semantic version (`X.Y.Z`).
+4. The tag must point at the exact commit on `origin/main` that contains release metadata.
+5. Do not move release tags unless there is a confirmed release mistake.
+
+## Release Preparation
+
+1. Create a release prep branch from `origin/main` (for example, `prepare-1-0-12`).
+2. Update:
+   - `pubspec.yaml` version
+   - `CHANGELOG.md` entry for the new version
+   - version links at the bottom of `CHANGELOG.md`
+3. Open a PR with title `Prepare <version> release metadata`.
+4. Ensure CI is green for the PR:
+   - formatting
+   - analysis
+   - tests
+
+## Merge and Publish
+
+1. Squash-merge the release PR into `main`.
+2. Delete the release prep branch.
+3. Fetch latest refs and resolve `origin/main` SHA.
+4. Create annotated tag `<version>` on that SHA.
+5. Push the tag to `origin` to trigger publish workflow.
+
+## Verification
+
+1. Confirm GitHub publish workflow starts from tag push.
+2. Confirm publish workflow succeeds.
+3. Confirm version appears on pub.dev.
+
+## Branch Hygiene
+
+After successful publish:
+
+1. Delete temporary feature/release branches locally and remotely.
+2. Keep only long-lived branches (`main`).


### PR DESCRIPTION
## Summary
- add `RELEASE.md` as the project release policy and checklist source of truth
- add a dedicated release PR template at `.github/PULL_REQUEST_TEMPLATE/release.md`
- add a README pointer to the release policy for maintainers

## Why
We now have established release rules (version/changelog/tag flow, PR-only merges, branch hygiene). This PR stores those rules in-repo so the process is repeatable and reviewable.
