### PR TITLE
Prepare 1.0.13 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.13] - 2026-07-07
+
+### Added
+- Added first-class support for `TRIGGER;RELATED` metadata through `Trigger.related` and `Trigger.relatedName`.
+
+### Fixed
+- Enforced stricter TRIGGER parameter validation for duplicate `VALUE` and invalid `RELATED` usage with `DATE-TIME`.
+
 ## [1.0.12] - 2026-07-05
 
 ### Improved
@@ -117,6 +125,7 @@ All notable changes to this project will be documented in this file.
 - Timezone-aware date/time handling
 - Two-layer architecture (document + semantic)
 
+[1.0.13]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.13
 [1.0.12]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.12
 [1.0.11]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.11
 [1.0.10]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.10

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firstfloor_calendar
 description: RFC 5545 compliant iCalendar (.ics) parser for Dart and Flutter.
-version: 1.0.12
+version: 1.0.13
 repository: https://github.com/firstfloorsoftware/firstfloor_calendar
 topics:
   - icalendar


### PR DESCRIPTION
## Summary
- bump package version to `1.0.13`
- add `1.0.13` changelog entry
- add release link entry for `1.0.13`

## Includes
- Trigger `RELATED` metadata support (`Trigger.related` / `Trigger.relatedName`)
- stricter TRIGGER parser validation for duplicate `VALUE` and invalid `RELATED` with `DATE-TIME`

## Validation
- `dart analyze --fatal-infos`
- `dart test`
- `dart pub outdated`
