### PR TITLE
Clarify branch cleanup rule in release policy

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,7 @@ Use this process for every published version (for example, `1.0.12`).
 3. Publish is triggered by a Git tag matching the semantic version (`X.Y.Z`).
 4. The tag must point at the exact commit on `origin/main` that contains release metadata.
 5. Do not move release tags unless there is a confirmed release mistake.
+6. Whenever a remote branch is deleted, delete the matching local branch in the same flow.
 
 ## Release Preparation
 
@@ -45,5 +46,5 @@ Use this process for every published version (for example, `1.0.12`).
 
 After successful publish:
 
-1. Delete temporary feature/release branches locally and remotely.
+1. Delete temporary feature/release branches on remote and local together.
 2. Keep only long-lived branches (`main`).


### PR DESCRIPTION
## Summary
- update `RELEASE.md` to explicitly require deleting local branch whenever deleting remote branch
- align branch hygiene wording to require remote+local cleanup together
