### PR TITLE
Prepare 1.0.14 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.14] - 2026-07-15
+
+### Fixed
+- Fixed `CalDuration.toString()` zero-length serialization to emit valid ISO 8601 (`PT0S` / `-PT0S`) for reliable round-tripping.
+
 ## [1.0.13] - 2026-07-07
 
 ### Added
@@ -125,6 +130,7 @@ All notable changes to this project will be documented in this file.
 - Timezone-aware date/time handling
 - Two-layer architecture (document + semantic)
 
+[1.0.14]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.14
 [1.0.13]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.13
 [1.0.12]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.12
 [1.0.11]: https://github.com/firstfloorsoftware/firstfloor_calendar/releases/tag/v1.0.11

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firstfloor_calendar
 description: RFC 5545 compliant iCalendar (.ics) parser for Dart and Flutter.
-version: 1.0.13
+version: 1.0.14
 repository: https://github.com/firstfloorsoftware/firstfloor_calendar
 topics:
   - icalendar

--- a/test/semantic/calendar_types_test.dart
+++ b/test/semantic/calendar_types_test.dart
@@ -176,7 +176,9 @@ void main() {
 
     test('zero duration roundtrips through serialization', () {
       final dur = CalDuration();
-      final property = DocumentParser.parseProperty('DURATION:${dur.toString()}');
+      final property = DocumentParser.parseProperty(
+        'DURATION:${dur.toString()}',
+      );
       final parsed = parseCalDuration(property);
       expect(parsed, equals(dur));
     });


### PR DESCRIPTION
## Summary
- bump package version to 1.0.14
- add 1.0.14 changelog entry for CalDuration zero-length serialization fix
- update changelog version link for 1.0.14
- include required formatting update from merged PR #45 so release CI stays green

## Validation
- dart pub get
- dart format --set-exit-if-changed .
- dart analyze --fatal-infos
- dart test